### PR TITLE
fix missing 'loader-utils' error in older npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jsdoc-oblivion": "0.0.4",
     "jsdoc-to-markdown": "^1.2.1",
     "load-grunt-configs": "^0.4.3",
+    "loader-utils": "^0.2.12",
     "lodash": "^3.10.1",
     "node-sass": "^3.4.2",
     "npm": "^3.3.12",


### PR DESCRIPTION
encountered error with node v0.12.7, npm 2.11.3 after running "webpack:dev" (webpack) task

ERROR in Cannot find module 'loader-utils'
 @ ./sources/js/_main-behavior.js 19:0-54
Warning: Task "webpack:dev" failed. Use --force to continue.
Aborted due to warnings.
