### PR TITLE
Fixes "param" is not a function error in generateId

### DIFF
--- a/sources/js/utils/rb_fetchmanager.js
+++ b/sources/js/utils/rb_fetchmanager.js
@@ -10,7 +10,7 @@
     'use strict';
     var rb = window.rb;
     var $ = rb.$;
-    var param = rb.param;
+    var param = $.param;
     var fetch = rb.fetch;
 
     var FetchManager = function(managerId, options){


### PR DESCRIPTION
if headers-options are set
