### PR TITLE
Prevent DOMException if data storage is disabled

### DIFF
--- a/sources/js/utils/rb_storage.js
+++ b/sources/js/utils/rb_storage.js
@@ -16,7 +16,13 @@
     rb.storage = {};
 
     ['session', 'local'].forEach(function(type){
-        var storage = window[type + 'Storage'];
+        var storage = undefined;
+        try{
+            storage = window[type + 'Storage'];
+        }
+        catch(e){
+            storage = {};
+        }
         var testStr = rb.getID();
 
         rb.storage[type] = {

--- a/sources/js/utils/rb_storage.js
+++ b/sources/js/utils/rb_storage.js
@@ -16,15 +16,16 @@
     rb.storage = {};
 
     ['session', 'local'].forEach(function(type){
-        var storage = undefined;
+        var storage;
+        var testStr = rb.getID();
+        
         try{
             storage = window[type + 'Storage'];
         }
         catch(e){
             storage = {};
         }
-        var testStr = rb.getID();
-
+        
         rb.storage[type] = {
             set: function(name, value){
                 try {


### PR DESCRIPTION
At least Chrome throws an Exception when trying to access window.XXXstorage and user has disabled data storage:
> Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.

This happens as soon as you try to access the storage, so additional try-catch is needed.

![bildschirmfoto vom 2016-10-31 14-15-43](https://cloud.githubusercontent.com/assets/19982047/19886420/759147ce-a023-11e6-8955-b4e31c506ff2.png)
